### PR TITLE
Add bot management API and runtime sync

### DIFF
--- a/alembic/versions/20240305_01_add_bot_runtime_fields.py
+++ b/alembic/versions/20240305_01_add_bot_runtime_fields.py
@@ -1,0 +1,79 @@
+"""Add runtime configuration fields to bots.
+
+Revision ID: 20240305_01
+Revises: 0b4a38b97487
+Create Date: 2024-03-05 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20240305_01"
+down_revision: Union[str, Sequence[str], None] = "0b4a38b97487"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+SIDE_MODE_ENUM = sa.Enum("both", "long_only", "short_only", name="side_mode_enum")
+BOT_STATUS_ENUM = sa.Enum("active", "paused", "ended", name="bot_status_enum")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    SIDE_MODE_ENUM.create(bind, checkfirst=True)
+    BOT_STATUS_ENUM.create(bind, checkfirst=True)
+
+    op.add_column(
+        "bots",
+        sa.Column("side_mode", SIDE_MODE_ENUM, nullable=False, server_default="both"),
+    )
+    op.add_column(
+        "bots",
+        sa.Column("status", BOT_STATUS_ENUM, nullable=False, server_default="active"),
+    )
+    op.add_column(
+        "bots",
+        sa.Column("risk_per_trade", sa.Numeric(12, 8), nullable=False, server_default="0.00500000"),
+    )
+    op.add_column(
+        "bots",
+        sa.Column("tp_ratio", sa.Numeric(8, 4), nullable=False, server_default="1.5000"),
+    )
+    op.add_column(
+        "bots",
+        sa.Column("max_qty", sa.Numeric(18, 8), nullable=True),
+    )
+
+    op.execute(
+        """
+        UPDATE bots
+        SET side_mode = CASE
+            WHEN side_whitelist = 'long' THEN 'long_only'
+            WHEN side_whitelist = 'short' THEN 'short_only'
+            ELSE 'both'
+        END
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE bots
+        SET status = CASE
+            WHEN enabled IS TRUE THEN 'active'
+            ELSE 'paused'
+        END
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("bots", "max_qty")
+    op.drop_column("bots", "tp_ratio")
+    op.drop_column("bots", "risk_per_trade")
+    op.drop_column("bots", "status")
+    op.drop_column("bots", "side_mode")
+
+    bind = op.get_bind()
+    BOT_STATUS_ENUM.drop(bind, checkfirst=True)
+    SIDE_MODE_ENUM.drop(bind, checkfirst=True)

--- a/app/api/bots.py
+++ b/app/api/bots.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.db.models.bots import Bot
+from app.db.models.user import User
+from app.db.models.credentials import ApiCredential
+from app.db.schemas.bots import BotCreate, BotOut, BotUpdate
+from app.services.tasks.admin import available_symbols, list_signal_stream_pairs, sync_bot_runtime
+
+router = APIRouter(prefix="/bots", tags=["Bots"])
+
+
+class BotStream(BaseModel):
+    symbol: str
+    timeframe: str
+
+
+def _map_side_mode_to_whitelist(mode: str) -> str:
+    mapping = {
+        "both": "both",
+        "long_only": "long",
+        "short_only": "short",
+    }
+    return mapping.get(mode, "both")
+
+
+async def _get_user(db: AsyncSession, user_id: UUID) -> User:
+    user = await db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return user
+
+
+async def _get_credential(db: AsyncSession, cred_id: UUID, user_id: UUID) -> ApiCredential:
+    cred = await db.get(ApiCredential, cred_id)
+    if not cred or cred.user_id != user_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Credential not found")
+    return cred
+
+
+@router.get("/streams", response_model=List[BotStream])
+async def list_streams() -> List[BotStream]:
+    streams = list_signal_stream_pairs()
+    return [BotStream(symbol=sym, timeframe=tf) for sym, tf in streams]
+
+
+@router.get("/", response_model=List[BotOut])
+async def list_bots(db: AsyncSession = Depends(get_db)) -> List[BotOut]:
+    result = await db.execute(select(Bot).order_by(Bot.created_at))
+    bots = result.scalars().all()
+    return list(bots)
+
+
+@router.get("/{bot_id}", response_model=BotOut)
+async def get_bot(bot_id: UUID, db: AsyncSession = Depends(get_db)) -> BotOut:
+    bot = await db.get(Bot, bot_id)
+    if not bot:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bot not found")
+    return bot
+
+
+@router.post("/", response_model=BotOut, status_code=status.HTTP_201_CREATED)
+async def create_bot(payload: BotCreate, db: AsyncSession = Depends(get_db)) -> BotOut:
+    symbol = payload.symbol.upper()
+    available = available_symbols()
+    if available and symbol not in available:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_symbol", "message": f"Symbol '{symbol}' not available"},
+        )
+
+    await _get_user(db, payload.user_id)
+    cred = await _get_credential(db, payload.cred_id, payload.user_id)
+
+    if cred.env != payload.env:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "env_mismatch", "message": "Credential environment mismatch"},
+        )
+
+    bot = Bot(
+        user_id=payload.user_id,
+        cred_id=payload.cred_id,
+        symbol=symbol,
+        timeframe=payload.timeframe,
+        env=payload.env,
+        side_mode=payload.side_mode,
+        side_whitelist=_map_side_mode_to_whitelist(payload.side_mode),
+        leverage=payload.leverage,
+        risk_per_trade=payload.risk_per_trade,
+        tp_ratio=payload.tp_ratio,
+        status=payload.status,
+        max_qty=payload.max_qty,
+        nickname=payload.nickname,
+        enabled=(payload.status == "active"),
+    )
+
+    db.add(bot)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+    await db.refresh(bot)
+
+    sync_bot_runtime(bot)
+
+    return bot
+
+
+@router.patch("/{bot_id}", response_model=BotOut)
+async def update_bot(bot_id: UUID, payload: BotUpdate, db: AsyncSession = Depends(get_db)) -> BotOut:
+    bot = await db.get(Bot, bot_id)
+    if not bot:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bot not found")
+
+    updated = False
+
+    if payload.side_mode is not None:
+        bot.side_mode = payload.side_mode
+        bot.side_whitelist = _map_side_mode_to_whitelist(payload.side_mode)
+        updated = True
+
+    if payload.leverage is not None:
+        bot.leverage = payload.leverage
+        updated = True
+
+    if payload.risk_per_trade is not None:
+        bot.risk_per_trade = payload.risk_per_trade
+        updated = True
+
+    if payload.tp_ratio is not None:
+        bot.tp_ratio = payload.tp_ratio
+        updated = True
+
+    if payload.max_qty is not None:
+        bot.max_qty = payload.max_qty
+        updated = True
+
+    if payload.nickname is not None:
+        bot.nickname = payload.nickname
+        updated = True
+
+    if payload.status is not None:
+        if bot.status == "ended" and payload.status != "ended":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"code": "immutable", "message": "Ended bots cannot transition"},
+            )
+        bot.status = payload.status
+        bot.enabled = payload.status == "active"
+        updated = True
+
+    if not updated:
+        return bot
+
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+    await db.refresh(bot)
+
+    sync_bot_runtime(bot)
+
+    return bot

--- a/app/db/models/bots.py
+++ b/app/db/models/bots.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 from uuid import uuid4
+from decimal import Decimal
 from sqlalchemy import (
-    Column, String, Boolean, Integer, DateTime, ForeignKey, Index,
-    Numeric
+    Column,
+    String,
+    Boolean,
+    Integer,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
@@ -13,6 +20,8 @@ from app.db.base import Base
 
 EnvEnum = SAEnum("testnet", "prod", name="env_enum", create_type=True)
 SideWhitelistEnum = SAEnum("long", "short", "both", name="side_whitelist_enum", create_type=True)
+SideModeEnum = SAEnum("both", "long_only", "short_only", name="side_mode_enum", create_type=True)
+BotStatusEnum = SAEnum("active", "paused", "ended", name="bot_status_enum", create_type=True)
 
 
 
@@ -30,8 +39,25 @@ class Bot(Base):
     timeframe = Column(String(8), nullable=False, default="2m") 
     enabled = Column(Boolean, nullable=False, default=True)
     env = Column(EnvEnum, nullable=False, server_default="testnet") 
-    side_whitelist = Column(SideWhitelistEnum, nullable=False, server_default="both")
-    leverage = Column(Integer, nullable=False, default=5) 
+    side_whitelist = Column(SideWhitelistEnum, nullable=False, default="both", server_default="both")
+    side_mode = Column(SideModeEnum, nullable=False, default="both", server_default="both")
+    leverage = Column(Integer, nullable=False, default=5)
+
+    status = Column(BotStatusEnum, nullable=False, default="active", server_default="active")
+
+    risk_per_trade = Column(
+        Numeric(12, 8),
+        nullable=False,
+        default=Decimal("0.005"),
+        server_default="0.00500000",
+    )
+    tp_ratio = Column(
+        Numeric(8, 4),
+        nullable=False,
+        default=Decimal("1.5"),
+        server_default="1.5000",
+    )
+    max_qty = Column(Numeric(18, 8), nullable=True)
 
     # --- sizing (MVP) ---
     use_balance_pct = Column(Boolean, nullable=False, default=True)

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ import logging
 
 from app.api.health import router as health_router
 from app.api.auth import router as auth_router
+from app.api.bots import router as bots_router
 
 
 logging.basicConfig(
@@ -59,3 +60,4 @@ app.add_middleware(
 #router
 app.include_router(health_router)
 app.include_router(auth_router)
+app.include_router(bots_router)

--- a/app/scripts/seed_bot.py
+++ b/app/scripts/seed_bot.py
@@ -110,9 +110,11 @@ def upsert_bot(session, user, cred, symbol="BTCUSDT"):
         enabled=True,
         env="testnet",
         side_whitelist="both",
+        side_mode="both",
         leverage=5,
-        use_balance_pct=True,
-        balance_pct="0.0050",  # ~0.5% free balance per trade
+        status="active",
+        risk_per_trade=Decimal("0.005"),
+        tp_ratio=Decimal("1.5"),
     )
     session.add(b)
     session.flush()

--- a/app/services/tasks/admin.py
+++ b/app/services/tasks/admin.py
@@ -1,0 +1,94 @@
+"""Helpers for managing bot runtime configuration in Redis."""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import List, Optional, Set, Tuple, TYPE_CHECKING
+import logging
+
+from redis.exceptions import RedisError
+
+from app.config import settings
+from app.services.ingestor import redis_io
+from app.services.tasks.state import write_bot_config, index_bot, deindex_bot
+
+if TYPE_CHECKING:  # pragma: no cover - only for typing
+    from app.db.models.bots import Bot
+
+
+LOG = logging.getLogger(__name__)
+
+_STREAM_MATCH = "stream:signal|{*}"
+
+
+def _to_decimal(value: Optional[object]) -> Optional[Decimal]:
+    if value is None or value == "":
+        return None
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def list_signal_stream_pairs() -> List[Tuple[str, str]]:
+    """Return available (symbol, timeframe) pairs discovered in Redis."""
+    pairs: Set[Tuple[str, str]] = set()
+
+    try:
+        cursor: int = 0
+        while True:
+            cursor, keys = redis_io.r.scan(cursor=cursor, match=_STREAM_MATCH, count=200)
+            for key in keys:
+                if not key:
+                    continue
+                key_str = key.decode("utf-8") if isinstance(key, (bytes, bytearray)) else str(key)
+                tag_start = key_str.find("{")
+                tag_end = key_str.find("}", tag_start + 1)
+                if tag_start == -1 or tag_end == -1:
+                    continue
+                tag = key_str[tag_start + 1 : tag_end]
+                if ":" in tag:
+                    sym, tf = tag.split(":", 1)
+                else:
+                    sym, tf = tag, ""
+                pairs.add((sym.upper(), tf))
+            if cursor == 0:
+                break
+    except RedisError as exc:  # pragma: no cover - defensive logging path
+        LOG.warning("Failed to scan Redis for signal streams: %s", exc)
+
+    if not pairs:
+        for sym, tf in settings.pairs_1m_list():
+            pairs.add((sym.upper(), tf))
+
+    return sorted(pairs)
+
+
+def available_symbols() -> Set[str]:
+    return {sym for sym, _ in list_signal_stream_pairs()}
+
+
+def sync_bot_runtime(bot: "Bot") -> None:
+    """Persist the bot's runtime configuration in Redis and update indexes."""
+    cfg = {
+        "bot_id": str(bot.id),
+        "user_id": str(bot.user_id),
+        "sym": (bot.symbol or "").upper(),
+        "side_mode": (bot.side_mode or "both"),
+        "status": (bot.status or "active"),
+        "risk_per_trade": _to_decimal(bot.risk_per_trade) or Decimal("0.005"),
+        "leverage": _to_decimal(bot.leverage) or Decimal("1"),
+        "tp_ratio": _to_decimal(bot.tp_ratio) or Decimal("1.5"),
+    }
+
+    max_qty = _to_decimal(getattr(bot, "max_qty", None))
+    if max_qty:
+        cfg["max_qty"] = max_qty
+
+    write_bot_config(str(bot.id), cfg)
+
+    status = cfg.get("status", "active")
+    symbol = cfg.get("sym", "")
+
+    if status == "ended":
+        deindex_bot(symbol, str(bot.id))
+    else:
+        index_bot(symbol, str(bot.id))

--- a/app/services/tasks/contracts.py
+++ b/app/services/tasks/contracts.py
@@ -89,7 +89,7 @@ class BracketPayloads(TypedDict):
 # Bot configuration & state
 
 SideMode = Literal["both", "long_only", "short_only"]
-BotStatus = Literal["active", "paused"]
+BotStatus = Literal["active", "paused", "ended"]
 
 
 class BotConfig(TypedDict, total=False):

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -44,6 +44,8 @@ if "app.config" not in sys.modules:
     cfgpkg = types.ModuleType("app.config")
 
     class _Settings:
+        REDIS_URL = None
+
         def pairs_1m_list(self):
             return [("BTCUSDT", "1m")]
 

--- a/app/tests/services/unit/test_tasks_admin.py
+++ b/app/tests/services/unit/test_tasks_admin.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from uuid import uuid4
+
+from app.services.tasks.admin import available_symbols, list_signal_stream_pairs, sync_bot_runtime
+from app.services.tasks.state import read_bot_config, bots_for_symbol
+
+
+def test_list_signal_stream_pairs_reads_redis(fake_redis):
+    fake_redis.xadd("stream:signal|{ETHUSDT:2m}", {"type": "arm", "sym": "ETHUSDT"})
+    pairs = list_signal_stream_pairs()
+    assert ("ETHUSDT", "2m") in pairs
+
+
+def test_available_symbols_falls_back_to_settings(fake_redis):
+    # With no streams seeded, fallback returns configured pairs (from conftest stub)
+    symbols = available_symbols()
+    assert "BTCUSDT" in symbols
+
+
+def test_sync_bot_runtime_persists_config_and_index(fake_redis):
+    bot_id = uuid4()
+    user_id = uuid4()
+    bot = SimpleNamespace(
+        id=bot_id,
+        user_id=user_id,
+        symbol="btcusdt",
+        side_mode="both",
+        status="active",
+        risk_per_trade=Decimal("0.010"),
+        leverage=5,
+        tp_ratio=Decimal("1.8"),
+        max_qty=None,
+    )
+
+    sync_bot_runtime(bot)
+
+    cfg = read_bot_config(str(bot_id))
+    assert cfg["sym"] == "BTCUSDT"
+    assert cfg["risk_per_trade"] == Decimal("0.010")
+    assert str(bot_id) in bots_for_symbol("BTCUSDT")
+
+
+def test_sync_bot_runtime_deindexes_ended_bot(fake_redis):
+    bot_id = uuid4()
+    user_id = uuid4()
+    bot = SimpleNamespace(
+        id=bot_id,
+        user_id=user_id,
+        symbol="btcusdt",
+        side_mode="both",
+        status="ended",
+        risk_per_trade=Decimal("0.010"),
+        leverage=5,
+        tp_ratio=Decimal("1.8"),
+        max_qty=None,
+    )
+
+    sync_bot_runtime(bot)
+
+    assert str(bot_id) not in bots_for_symbol("BTCUSDT")


### PR DESCRIPTION
## Summary
- add a FastAPI bots router for creating, listing, and updating bots plus a stream discovery endpoint
- expand bot persistence (models, schemas, migration) with risk, tp ratio, status, and side mode fields and sync them to Redis via a new task admin helper
- update Redis state adapters to share the fake Redis client in tests and add unit coverage for the admin helpers

## Testing
- pytest app/tests/services/unit/test_tasks_admin.py
- pytest app/tests/services/unit/test_state_io.py

------
https://chatgpt.com/codex/tasks/task_e_68de0f044f908322aa56f585906ef1cc