### PR TITLE
Add legacy Binance exchange facade and helpers

### DIFF
--- a/app/services/tasks/__init__.py
+++ b/app/services/tasks/__init__.py
@@ -1,0 +1,7 @@
+"""Legacy task-layer facade wiring.
+
+This package exposes synchronous helper functions used by Celery tasks and
+scripts.  Modern code paths in ``app.services.worker`` provide the async
+implementations; these wrappers keep backwards compatibility for tests and
+tooling that still import ``app.services.tasks.*``.
+"""

--- a/app/services/tasks/exchange.py
+++ b/app/services/tasks/exchange.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Callable, Dict, Iterable, Mapping, MutableMapping, Optional, Tuple
+from urllib.parse import urlencode
+
+import requests
+
+try:  # pragma: no cover - exercised via tests with a stub
+    from binance_sdk_derivatives_trading_usds_futures.derivatives_trading_usds_futures import (
+        ConfigurationRestAPI,
+        DERIVATIVES_TRADING_USDS_FUTURES_REST_API_PROD_URL,
+        DerivativesTradingUsdsFutures,
+    )
+except Exception as exc:  # pragma: no cover - defensive guard for missing dependency
+    raise RuntimeError(
+        "Binance USDS futures SDK is required (pip install binance-futures-connector)."
+    ) from exc
+
+# Some SDK builds export a TESTNET URL constant; provide a safe fallback if absent.
+try:  # pragma: no cover - attribute availability depends on SDK version
+    from binance_sdk_derivatives_trading_usds_futures.derivatives_trading_usds_futures import (
+        DERIVATIVES_TRADING_USDS_FUTURES_REST_API_TESTNET_URL,
+    )
+except Exception:  # pragma: no cover - best effort fallback
+    DERIVATIVES_TRADING_USDS_FUTURES_REST_API_TESTNET_URL = "https://testnet.binancefuture.com"
+
+
+log = logging.getLogger("app.services.tasks.exchange")
+
+_DEFAULT_TIMEOUT_SECONDS = int(os.getenv("BINANCE_USDSF_TIMEOUT", "30"))
+_HTTP_TIMEOUT = max(_DEFAULT_TIMEOUT_SECONDS, 10)
+
+_ClientKey = Tuple[str, str, str]
+_CLIENT_CACHE: Dict[_ClientKey, DerivativesTradingUsdsFutures] = {}
+_CLIENT_LOCK = threading.RLock()
+_CREDS_LOOKUP: Optional[Callable[[str], Tuple[str, str, Optional[str]]]] = None
+
+
+@dataclass(frozen=True)
+class _Creds:
+    api_key: str
+    api_secret: str
+    base_url: str
+
+
+def set_creds_lookup(func: Optional[Callable[[str], Tuple[str, str, Optional[str]]]]) -> None:
+    """Install a user->(api_key, api_secret, base_url) resolver.
+
+    Passing ``None`` clears the lookup and falls back to environment variables.
+    The client cache is cleared so subsequent calls pick up new credentials.
+    """
+
+    global _CREDS_LOOKUP
+    if func is not None and not callable(func):  # pragma: no cover - defensive
+        raise TypeError("set_creds_lookup expects a callable or None")
+    _CREDS_LOOKUP = func
+    clear_client_cache()
+    log.info("set_creds_lookup installed -> cache cleared")
+
+
+def clear_client_cache() -> None:
+    with _CLIENT_LOCK:
+        _CLIENT_CACHE.clear()
+
+
+def _resolve_creds(user_id: str) -> _Creds:
+    """Resolve credentials for *user_id* via lookup or environment defaults."""
+
+    api_key = os.getenv("BINANCE_USDSF_API_KEY", "")
+    api_secret = os.getenv("BINANCE_USDSF_API_SECRET", "")
+    base_url = os.getenv("BINANCE_USDSF_BASE_URL", "").strip()
+
+    if _CREDS_LOOKUP is not None:
+        try:
+            resolved = _CREDS_LOOKUP(user_id)
+        except Exception as exc:  # pragma: no cover - propagation tested via callers
+            log.exception("creds lookup failed | user_id=%s", user_id)
+            raise RuntimeError(f"credential lookup failed for {user_id}: {exc}") from exc
+        if not isinstance(resolved, Iterable):  # pragma: no cover - defensive
+            raise RuntimeError("credential lookup must return an iterable of length 2 or 3")
+        try:
+            api_key, api_secret, *rest = resolved  # type: ignore[misc]
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise RuntimeError("credential lookup must return 2 or 3 elements") from exc
+        if rest:
+            base_url = (rest[0] or "").strip()
+
+    base_url = base_url or DERIVATIVES_TRADING_USDS_FUTURES_REST_API_PROD_URL
+    return _Creds(api_key=str(api_key), api_secret=str(api_secret), base_url=base_url)
+
+
+def _client_for_user(
+    user_id: str,
+    api_key: Optional[str] = None,
+    api_secret: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> DerivativesTradingUsdsFutures:
+    """Return (and cache) a configured SDK client for ``user_id``."""
+
+    if api_key is None or api_secret is None or base_url is None:
+        creds = _resolve_creds(user_id)
+    else:
+        creds = _Creds(api_key, api_secret, base_url or DERIVATIVES_TRADING_USDS_FUTURES_REST_API_PROD_URL)
+
+    cache_key: _ClientKey = (user_id, creds.base_url, creds.api_key)
+    with _CLIENT_LOCK:
+        client = _CLIENT_CACHE.get(cache_key)
+        if client is not None:
+            return client
+
+        try:
+            conf = ConfigurationRestAPI(
+                api_key=creds.api_key,
+                api_secret=creds.api_secret,
+                base_path=creds.base_url,
+                timeout=_DEFAULT_TIMEOUT_SECONDS * 1000,
+            )
+        except TypeError:  # pragma: no cover - exercised by contract tests with a stub
+            conf = ConfigurationRestAPI(
+                api_key=creds.api_key,
+                api_secret=creds.api_secret,
+                base_path=creds.base_url,
+            )
+        client = DerivativesTradingUsdsFutures(config_rest_api=conf)
+        _CLIENT_CACHE[cache_key] = client
+        log.info("created new Binance SDK client | user_id=%s base=%s", user_id, creds.base_url)
+        return client
+
+
+def _unwrap(resp: Any) -> Any:
+    """Normalise SDK responses that expose ``data``/``data()`` helpers."""
+
+    if resp is None:
+        return None
+    for attr in ("data", "data"):
+        try:
+            value = getattr(resp, attr)
+        except Exception:
+            continue
+        if callable(value):
+            try:
+                return value()
+            except Exception:
+                continue
+        return value
+    return resp
+
+
+def _numeric(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return float(value)
+    return value
+
+
+def _build_order_payload(kwargs: Mapping[str, Any]) -> Dict[str, Any]:
+    symbol = kwargs.get("symbol")
+    side = kwargs.get("side")
+    order_type = str(kwargs.get("order_type", "")).upper()
+    payload: Dict[str, Any] = {
+        "symbol": str(symbol).upper() if symbol else symbol,
+        "side": str(side).upper() if side else side,
+        "type": order_type,
+    }
+
+    qty = kwargs.get("quantity")
+    if qty is not None:
+        payload["quantity"] = _numeric(qty)
+
+    price = kwargs.get("price")
+    time_in_force = kwargs.get("timeInForce")
+    stop_price = kwargs.get("stop_price")
+
+    # STOP/TAKE_PROFIT (non-market) behave like stop-limit orders.
+    if order_type in {"STOP", "TAKE_PROFIT"}:
+        if stop_price is not None:
+            payload["stopPrice"] = _numeric(stop_price)
+        if price is not None:
+            payload["price"] = _numeric(price)
+        if time_in_force is not None:
+            payload["timeInForce"] = time_in_force
+    elif order_type in {"STOP_MARKET", "TAKE_PROFIT_MARKET", "MARKET"}:
+        if stop_price is not None:
+            payload["stopPrice"] = _numeric(stop_price)
+        # Explicitly drop price/timeInForce for market variants.
+    else:  # e.g. LIMIT
+        if price is not None:
+            payload["price"] = _numeric(price)
+        if time_in_force is not None:
+            payload["timeInForce"] = time_in_force
+        # LIMIT should not send stopPrice
+
+    mapping = {
+        "reduce_only": ("reduceOnly", bool if kwargs.get("reduce_only") is not None else None),
+        "working_type": "workingType",
+        "close_position": ("closePosition", bool if kwargs.get("close_position") is not None else None),
+        "client_order_id": "newClientOrderId",
+        "positionSide": "positionSide",
+        "priceProtect": ("priceProtect", bool if kwargs.get("priceProtect") is not None else None),
+    }
+
+    for src, dest in mapping.items():
+        value = kwargs.get(src)
+        if value is None:
+            continue
+        if isinstance(dest, tuple):
+            dest_name, coercer = dest
+            payload[dest_name] = coercer(value) if coercer else value
+        else:
+            payload[dest] = value if src != "positionSide" else str(value).upper()
+
+    # working_type maps from kw "working_type"
+    if "working_type" in kwargs and kwargs["working_type"] is not None:
+        payload["workingType"] = kwargs["working_type"]
+
+    # Remove any keys with value None to satisfy contract tests.
+    return {k: v for k, v in payload.items() if v is not None}
+
+
+def new_order(**kwargs: Any) -> Dict[str, Any]:
+    """Place a new order synchronously via the SDK REST client."""
+
+    user_id = kwargs.pop("user_id")
+    creds = _resolve_creds(user_id)
+    client = _client_for_user(user_id, creds.api_key, creds.api_secret, creds.base_url)
+
+    payload = _build_order_payload(kwargs)
+    try:
+        resp = client.rest_api.new_order(**payload)
+        data = _unwrap(resp) or {}
+        return {
+            "ok": True,
+            "order_id": data.get("orderId"),
+            "client_order_id": data.get("clientOrderId") or data.get("origClientOrderId"),
+            "raw": data,
+        }
+    except Exception as exc:  # pragma: no cover - exercised via tests
+        log.exception("new_order failed | user_id=%s", user_id)
+        return {"ok": False, "error": str(exc)}
+
+
+def cancel_order(user_id: str, symbol: str, order_id: Optional[int] = None, orig_client_order_id: Optional[str] = None) -> Dict[str, Any]:
+    creds = _resolve_creds(user_id)
+    client = _client_for_user(user_id, creds.api_key, creds.api_secret, creds.base_url)
+    params: Dict[str, Any] = {"symbol": str(symbol).upper()}
+    if order_id is not None:
+        params["orderId"] = int(order_id)
+    if orig_client_order_id is not None:
+        params["origClientOrderId"] = orig_client_order_id
+    try:
+        resp = client.rest_api.cancel_order(**params)
+        data = _unwrap(resp) or {}
+        return {"ok": True, "raw": data}
+    except Exception as exc:  # pragma: no cover - defensive
+        log.exception("cancel_order failed | user_id=%s", user_id)
+        return {"ok": False, "error": str(exc)}
+
+
+def get_open_orders(user_id: str, symbol: Optional[str] = None) -> Dict[str, Any]:
+    creds = _resolve_creds(user_id)
+    client = _client_for_user(user_id, creds.api_key, creds.api_secret, creds.base_url)
+    params = {"symbol": str(symbol).upper()} if symbol else {}
+    try:
+        resp = client.rest_api.current_all_open_orders(**params)
+        data = _unwrap(resp) or []
+        return {"ok": True, "orders": data}
+    except Exception as exc:  # pragma: no cover - defensive
+        log.exception("get_open_orders failed | user_id=%s", user_id)
+        return {"ok": False, "error": str(exc)}
+
+
+def get_positions(user_id: str, symbol: Optional[str] = None) -> Dict[str, Any]:
+    creds = _resolve_creds(user_id)
+    client = _client_for_user(user_id, creds.api_key, creds.api_secret, creds.base_url)
+    params = {"symbol": str(symbol).upper()} if symbol else {}
+    try:
+        resp = client.rest_api.position_information(**params)
+        data = _unwrap(resp) or []
+        return {"ok": True, "positions": data}
+    except Exception as exc:  # pragma: no cover
+        log.exception("get_positions failed | user_id=%s", user_id)
+        return {"ok": False, "error": str(exc)}
+
+
+def set_leverage(user_id: str, symbol: str, leverage: int) -> Dict[str, Any]:
+    creds = _resolve_creds(user_id)
+    client = _client_for_user(user_id, creds.api_key, creds.api_secret, creds.base_url)
+    try:
+        resp = client.rest_api.change_initial_leverage(symbol=str(symbol).upper(), leverage=int(leverage))
+        data = _unwrap(resp) or {}
+        return {"ok": True, "raw": data}
+    except Exception as exc:  # pragma: no cover
+        log.exception("set_leverage failed | user_id=%s", user_id)
+        return {"ok": False, "error": str(exc)}
+
+
+def set_margin_type(user_id: str, symbol: str, margin_type: str) -> Dict[str, Any]:
+    creds = _resolve_creds(user_id)
+    client = _client_for_user(user_id, creds.api_key, creds.api_secret, creds.base_url)
+    try:
+        resp = client.rest_api.change_margin_type(symbol=str(symbol).upper(), marginType=str(margin_type).upper())
+        data = _unwrap(resp) or {}
+        return {"ok": True, "raw": data}
+    except Exception as exc:  # pragma: no cover
+        log.exception("set_margin_type failed | user_id=%s", user_id)
+        return {"ok": False, "error": str(exc)}
+
+
+def _signed_get(base_url: str, path: str, api_key: str, api_secret: str, params: Optional[MutableMapping[str, Any]] = None) -> Dict[str, Any]:
+    params = dict(params or {})
+    params.setdefault("recvWindow", 5000)
+    params["timestamp"] = int(time.time() * 1000)
+    qs = urlencode(params)
+    signature = hmac.new(api_secret.encode(), qs.encode(), hashlib.sha256).hexdigest()
+    params["signature"] = signature
+    headers = {"X-MBX-APIKEY": api_key}
+    url = f"{base_url.rstrip('/')}{path}"
+    response = requests.get(url, params=params, headers=headers, timeout=_HTTP_TIMEOUT)
+    response.raise_for_status()
+    return response.json()
+
+
+def probe_position_mode(user_id: str) -> Dict[str, Any]:
+    creds = _resolve_creds(user_id)
+    try:
+        data = _signed_get(creds.base_url, "/fapi/v1/positionSide/dual", creds.api_key, creds.api_secret)
+    except Exception as exc:  # pragma: no cover - network dependent
+        log.exception("probe_position_mode failed | user_id=%s", user_id)
+        return {"ok": False, "error": str(exc)}
+
+    raw_value = data.get("dualSidePosition")
+    mode = "unknown"
+    if isinstance(raw_value, bool):
+        mode = "hedge" if raw_value else "one_way"
+    elif isinstance(raw_value, str):
+        lower = raw_value.lower()
+        if lower in {"true", "1"}:
+            mode = "hedge"
+        elif lower in {"false", "0"}:
+            mode = "one_way"
+
+    return {"ok": True, "mode": mode, "raw": data}
+
+
+def _exchange_info(base_url: str, symbol: str) -> Dict[str, Any]:
+    url = f"{base_url.rstrip('/')}/fapi/v1/exchangeInfo"
+    resp = requests.get(url, params={"symbol": symbol.upper()}, timeout=_HTTP_TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _extract_filters(info: Mapping[str, Any], symbol: str) -> Dict[str, Any]:
+    symbols = info.get("symbols") or []
+    for sym in symbols:
+        if str(sym.get("symbol")) == symbol.upper():
+            filters: Dict[str, Any] = {}
+            for f in sym.get("filters", []):
+                f_type = f.get("filterType")
+                if f_type == "PRICE_FILTER":
+                    filters["tick_size"] = f.get("tickSize")
+                elif f_type == "LOT_SIZE":
+                    filters["step_size"] = f.get("stepSize")
+                    filters["min_qty"] = f.get("minQty")
+                elif f_type in {"MIN_NOTIONAL", "NOTIONAL"}:
+                    filters["min_notional"] = f.get("notional") or f.get("minNotional")
+            return filters
+    return {}
+
+
+def _selftest_probe(user_id: str, symbol: str) -> Dict[str, Any]:
+    creds = _resolve_creds(user_id)
+    try:
+        info = _exchange_info(creds.base_url, symbol)
+        filters = _extract_filters(info, symbol)
+        position_mode = probe_position_mode(user_id)
+    except Exception as exc:  # pragma: no cover - network dependent
+        log.exception("_selftest_probe failed | user_id=%s", user_id)
+        return {"ok": False, "error": str(exc)}
+
+    ok = position_mode.get("ok", False)
+    return {
+        "ok": ok,
+        "exchange_info": info,
+        "filters": filters,
+        "position_mode": position_mode,
+    }
+
+
+__all__ = [
+    "set_creds_lookup",
+    "clear_client_cache",
+    "new_order",
+    "cancel_order",
+    "get_open_orders",
+    "get_positions",
+    "set_leverage",
+    "set_margin_type",
+    "probe_position_mode",
+    "_selftest_probe",
+    "_client_for_user",  # exposed for tests to monkeypatch
+]

--- a/app/services/tasks/exchange_filters.py
+++ b/app/services/tasks/exchange_filters.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_DOWN
+from typing import Dict, List, Tuple
+
+
+def _to_decimal(value) -> Decimal:
+    if value is None:
+        return Decimal("0")
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def round_price(price: Decimal, filters: Dict[str, Decimal | str]) -> Decimal:
+    tick = _to_decimal(filters.get("tick_size") or 0)
+    if tick <= 0:
+        return price
+    return (price // tick) * tick
+
+
+def round_qty(qty: Decimal, filters: Dict[str, Decimal | str]) -> Decimal:
+    step = _to_decimal(filters.get("step_size") or 0)
+    if step <= 0:
+        return qty
+    return (qty // step) * step
+
+
+def enforce_mins(price: Decimal, qty: Decimal, filters: Dict[str, Decimal | str]) -> Tuple[Decimal, Decimal, List[str]]:
+    warnings: List[str] = []
+    min_qty = _to_decimal(filters.get("min_qty") or 0)
+    min_notional = _to_decimal(filters.get("min_notional") or 0)
+
+    target_qty = qty
+    if min_qty > 0 and target_qty < min_qty:
+        target_qty = min_qty
+        warnings.append("enforced min_qty")
+
+    if min_notional > 0 and price > 0:
+        required_qty = (min_notional / price).quantize(Decimal("1.00000000"), rounding=ROUND_DOWN)
+        if required_qty > target_qty:
+            target_qty = required_qty
+            warnings.append("enforced min_notional")
+
+    if target_qty <= 0:
+        target_qty = Decimal("0")
+
+    return price, target_qty, warnings
+
+
+def apply_symbol_filters(payload: Dict[str, Decimal | str | float], filters: Dict[str, Decimal | str]) -> Dict[str, Decimal | str | float]:
+    out = dict(payload)
+
+    def _round_field(name: str) -> None:
+        if name in out and out[name] is not None:
+            out[name] = round_price(_to_decimal(out[name]), filters)
+
+    for field in ("price", "stop_price"):
+        _round_field(field)
+
+    qty = _to_decimal(out.get("quantity")) if out.get("quantity") is not None else Decimal("0")
+    price_for_notional = _to_decimal(out.get("price") or out.get("stop_price") or 0)
+    _, adj_qty, _ = enforce_mins(price_for_notional, qty, filters)
+    adj_qty = round_qty(adj_qty, filters)
+    out["quantity"] = adj_qty
+
+    return out
+
+
+__all__ = ["round_price", "round_qty", "enforce_mins", "apply_symbol_filters"]

--- a/app/services/tasks/payloads.py
+++ b/app/services/tasks/payloads.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict, Tuple
+
+from .exchange_filters import apply_symbol_filters
+
+
+def _side_to_exchange(side: str, *, entry: bool = True) -> str:
+    side = str(side).lower()
+    if entry:
+        return "BUY" if side == "long" else "SELL"
+    return "SELL" if side == "long" else "BUY"
+
+
+def _norm_filters(filters: Dict[str, object]) -> Dict[str, object]:
+    return dict(filters or {})
+
+
+def build_entry_order(
+    *,
+    sym: str,
+    side: str,
+    qty: Decimal,
+    trigger: Decimal,
+    working_type: str,
+    client_order_id: str,
+    filters: Dict[str, object],
+) -> Dict[str, object]:
+    payload = {
+        "symbol": sym.upper(),
+        "side": _side_to_exchange(side, entry=True),
+        "order_type": "STOP_MARKET",
+        "quantity": qty,
+        "stop_price": trigger,
+        "working_type": working_type,
+        "client_order_id": client_order_id,
+    }
+    return apply_symbol_filters(payload, _norm_filters(filters))
+
+
+def build_stop_loss_order(
+    *,
+    sym: str,
+    side: str,
+    qty: Decimal,
+    stop: Decimal,
+    working_type: str,
+    client_order_id: str,
+    filters: Dict[str, object],
+) -> Dict[str, object]:
+    payload = {
+        "symbol": sym.upper(),
+        "side": _side_to_exchange(side, entry=False),
+        "order_type": "STOP_MARKET",
+        "quantity": qty,
+        "stop_price": stop,
+        "working_type": working_type,
+        "client_order_id": client_order_id,
+        "reduce_only": True,
+        "close_position": True,
+    }
+    return apply_symbol_filters(payload, _norm_filters(filters))
+
+
+def build_take_profit_order(
+    *,
+    sym: str,
+    side: str,
+    qty: Decimal,
+    avg_entry_price: Decimal,
+    stop: Decimal,
+    tp_ratio: Decimal,
+    working_type: str,
+    client_order_id: str,
+    filters: Dict[str, object],
+) -> Tuple[Dict[str, object], Decimal]:
+    entry = Decimal(avg_entry_price)
+    stop_price = Decimal(stop)
+    ratio = Decimal(tp_ratio)
+    if side.lower() == "long":
+        distance = entry - stop_price
+        tp_price = entry + (distance * ratio)
+        order_type = "TAKE_PROFIT_MARKET"
+    else:
+        distance = stop_price - entry
+        tp_price = entry - (distance * ratio)
+        order_type = "TAKE_PROFIT_MARKET"
+
+    payload = {
+        "symbol": sym.upper(),
+        "side": _side_to_exchange(side, entry=False),
+        "order_type": order_type,
+        "quantity": qty,
+        "stop_price": tp_price,
+        "working_type": working_type,
+        "client_order_id": client_order_id,
+        "reduce_only": True,
+        "close_position": True,
+    }
+    payload = apply_symbol_filters(payload, _norm_filters(filters))
+    return payload, payload["stop_price"]  # post-filtered tp
+
+
+def build_brackets(
+    *,
+    sym: str,
+    side: str,
+    qty: Decimal,
+    avg_entry_price: Decimal,
+    stop: Decimal,
+    tp_ratio: Decimal,
+    working_type: str,
+    sl_client_order_id: str,
+    tp_client_order_id: str,
+    filters: Dict[str, object],
+) -> Tuple[Dict[str, Dict[str, object]], Decimal]:
+    sl = build_stop_loss_order(
+        sym=sym,
+        side=side,
+        qty=qty,
+        stop=stop,
+        working_type=working_type,
+        client_order_id=sl_client_order_id,
+        filters=filters,
+    )
+    tp_payload, tp_price = build_take_profit_order(
+        sym=sym,
+        side=side,
+        qty=qty,
+        avg_entry_price=avg_entry_price,
+        stop=stop,
+        tp_ratio=tp_ratio,
+        working_type=working_type,
+        client_order_id=tp_client_order_id,
+        filters=filters,
+    )
+    return {"stop_loss": sl, "take_profit": tp_payload}, tp_price
+
+
+__all__ = [
+    "build_entry_order",
+    "build_stop_loss_order",
+    "build_take_profit_order",
+    "build_brackets",
+]

--- a/app/services/tasks/sizing.py
+++ b/app/services/tasks/sizing.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict
+
+from .exchange_filters import enforce_mins, round_qty
+
+
+def _to_decimal(value) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def _normalise_filters(filters: Dict[str, object]) -> Dict[str, Decimal]:
+    out: Dict[str, Decimal] = {}
+    for key, value in (filters or {}).items():
+        try:
+            out[key] = _to_decimal(value)
+        except Exception:
+            out[key] = Decimal("0")
+    return out
+
+
+def compute_position_size(
+    *,
+    trigger: Decimal,
+    stop: Decimal,
+    balance_free: Decimal,
+    risk_per_trade: Decimal,
+    leverage: Decimal,
+    filters: Dict[str, object],
+) -> Dict[str, object]:
+    price = _to_decimal(trigger)
+    stop_price = _to_decimal(stop)
+    distance = abs(price - stop_price)
+    if distance <= 0:
+        return {
+            "ok": False,
+            "distance": Decimal("0"),
+            "qty": Decimal("0"),
+            "notes": ["invalid distance"],
+        }
+
+    risk_budget = _to_decimal(balance_free) * _to_decimal(risk_per_trade)
+    if risk_budget <= 0:
+        return {
+            "ok": False,
+            "distance": distance,
+            "qty": Decimal("0"),
+            "notes": ["no risk budget"],
+        }
+
+    lev = max(_to_decimal(leverage), Decimal("0"))
+    if price <= 0:
+        return {
+            "ok": False,
+            "distance": distance,
+            "qty": Decimal("0"),
+            "notes": ["invalid trigger price"],
+        }
+
+    notional = risk_budget * lev
+    qty = notional / price
+
+    norm_filters = _normalise_filters(filters)
+    _, qty, min_notes = enforce_mins(price, qty, norm_filters)
+    qty = round_qty(qty, norm_filters)
+
+    if qty <= 0:
+        notes = list(min_notes) or ["qty below exchange minimum"]
+        return {"ok": False, "distance": distance, "qty": Decimal("0"), "notes": notes}
+
+    return {
+        "ok": True,
+        "qty": qty,
+        "distance": distance,
+        "notional": price * qty,
+        "notes": list(min_notes),
+    }
+
+
+__all__ = ["compute_position_size"]


### PR DESCRIPTION
## Summary
- add synchronous Binance USDS futures facade used by legacy task layer
- provide exchange filter rounding, sizing, and payload helper utilities
- expose compatibility package so existing tests and scripts can import app.services.tasks

## Testing
- pipenv run pytest app/tests/services/unit/test_exchange_facade_contract.py
- pipenv run pytest app/tests/services/unit/test_exchange_filters_rounding.py
- pipenv run pytest app/tests/services/unit/test_sizing.py
- pipenv run pytest app/tests/services/unit/test_payload_builders.py

------
https://chatgpt.com/codex/tasks/task_e_69002bf095788322b13bd052734e3624