### PR TITLE
Implement signal refresh and correct exit orders

### DIFF
--- a/app/services/worker/domain/enums.py
+++ b/app/services/worker/domain/enums.py
@@ -41,6 +41,19 @@ class OrderSide(str, Enum):
         except Exception:
             return cls(str(value))
 
+    def exit_side(self) -> "OrderSide":
+        """Return the side that would close/reduce a position opened on ``self``."""
+        if self == OrderSide.LONG:
+            return OrderSide.SHORT
+        if self == OrderSide.SHORT:
+            return OrderSide.LONG
+        raise ValueError(f"Unsupported order side: {self}")
+
+
+def exit_side_for(entry_side: OrderSide) -> OrderSide:
+    """Helper function mirroring :meth:`OrderSide.exit_side` for functional use."""
+    return entry_side.exit_side()
+
 
 class SideWhitelist(str, Enum):
     """

--- a/tests/unit/calc2/test_signal_generator.py
+++ b/tests/unit/calc2/test_signal_generator.py
@@ -1,0 +1,108 @@
+from decimal import Decimal
+
+import pytest
+
+from app.services.calc2.signals.generator import SignalGenerator
+
+
+@pytest.fixture
+def generator() -> SignalGenerator:
+    return SignalGenerator(tick_size=Decimal("0.1"))
+
+
+def _arm_for(
+    gen: SignalGenerator,
+    *,
+    regime: str,
+    ind_ts: int,
+    ind_high: Decimal,
+    ind_low: Decimal,
+) -> None:
+    sigs = gen.maybe_signals(
+        sym="BTCUSDT",
+        tf="2m",
+        now_ts=ind_ts,
+        regime=regime,
+        ind_ts=ind_ts,
+        ind_high=ind_high,
+        ind_low=ind_low,
+    )
+    assert sigs, "Expected ARM signal to be emitted"
+    arm = sigs[-1]
+    assert getattr(arm, "type", None) == "arm"
+
+
+def test_indicator_update_emits_disarm_then_arm(generator: SignalGenerator) -> None:
+    # Prime generator with neutral then short regime (initial ARM)
+    assert generator.maybe_signals(
+        sym="BTCUSDT",
+        tf="2m",
+        now_ts=1,
+        regime="neutral",
+        ind_ts=1,
+        ind_high=Decimal("101"),
+        ind_low=Decimal("99"),
+    ) == []
+
+    sigs = generator.maybe_signals(
+        sym="BTCUSDT",
+        tf="2m",
+        now_ts=2,
+        regime="short",
+        ind_ts=2,
+        ind_high=Decimal("101"),
+        ind_low=Decimal("99"),
+    )
+    assert len(sigs) == 1
+    first_arm = sigs[0]
+    assert getattr(first_arm, "type", None) == "arm"
+    assert getattr(first_arm, "ind_ts", None) == 2
+
+    # Same regime, new indicator candle -> expect DISARM + new ARM
+    update_sigs = generator.maybe_signals(
+        sym="BTCUSDT",
+        tf="2m",
+        now_ts=3,
+        regime="short",
+        ind_ts=3,
+        ind_high=Decimal("102"),
+        ind_low=Decimal("100"),
+    )
+    assert len(update_sigs) == 2
+    disarm, new_arm = update_sigs
+    assert getattr(disarm, "type", None) == "disarm"
+    assert getattr(disarm, "reason", None) == "update_pending"
+    assert getattr(new_arm, "type", None) == "arm"
+    assert getattr(new_arm, "ind_ts", None) == 3
+
+
+def test_same_indicator_no_duplicate_signals(generator: SignalGenerator) -> None:
+    # Establish baseline neutral regime so subsequent ARM is emitted on transition
+    assert generator.maybe_signals(
+        sym="BTCUSDT",
+        tf="2m",
+        now_ts=9,
+        regime="neutral",
+        ind_ts=9,
+        ind_high=Decimal("104"),
+        ind_low=Decimal("99"),
+    ) == []
+
+    _arm_for(
+        generator,
+        regime="long",
+        ind_ts=10,
+        ind_high=Decimal("105"),
+        ind_low=Decimal("100"),
+    )
+
+    # Repeat with identical indicator timestamp -> expect no signals
+    assert generator.maybe_signals(
+        sym="BTCUSDT",
+        tf="2m",
+        now_ts=11,
+        regime="long",
+        ind_ts=10,
+        ind_high=Decimal("105"),
+        ind_low=Decimal("100"),
+    ) == []

--- a/tests/unit/core/test_bot_worker.py
+++ b/tests/unit/core/test_bot_worker.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.services.worker.core.worker import BotWorker
+from app.services.worker.domain.enums import OrderSide, OrderStatus, SideWhitelist
+from app.services.worker.domain.models import ArmSignal, BotConfig, OrderState
+
+
+class OrderExecutorStub:
+    def __init__(self, state: OrderState) -> None:
+        self._state = state
+
+    async def execute_order(self, bot: BotConfig, signal: ArmSignal) -> OrderState:
+        return self._state
+
+
+class PositionManagerStub:
+    def __init__(self, take_profit: Decimal) -> None:
+        self.calls: list[tuple] = []
+        self._tp = take_profit
+
+    async def open_position(self, bot_id, order_state):
+        self.calls.append((bot_id, order_state))
+        return SimpleNamespace(
+            take_profit=self._tp,
+            quantity=order_state.quantity,
+            symbol=order_state.symbol,
+        )
+
+
+class TradingStub:
+    def __init__(self, *, order_status: str = "FILLED") -> None:
+        self.stop_orders: list[dict] = []
+        self._status = order_status
+
+    async def create_stop_market_order(
+        self,
+        *,
+        symbol: str,
+        side,
+        quantity: Decimal,
+        stop_price: Decimal,
+        order_type: str = "STOP_MARKET",
+        **_: dict,
+    ) -> dict:
+        self.stop_orders.append(
+            {
+                "symbol": symbol,
+                "side": side,
+                "quantity": quantity,
+                "stop_price": stop_price,
+                "order_type": order_type,
+            }
+        )
+        return {"orderType": order_type}
+
+    async def cancel_order(self, *, symbol: str, order_id: int) -> None:  # pragma: no cover - unused in tests
+        self.cancelled = getattr(self, "cancelled", [])
+        self.cancelled.append({"symbol": symbol, "order_id": order_id})
+
+    async def get_order_status(self, *, symbol: str, order_id: int) -> str:
+        return self._status
+
+
+def _make_bot() -> BotConfig:
+    return BotConfig(
+        id=uuid4(),
+        user_id=uuid4(),
+        cred_id=uuid4(),
+        symbol="BTCUSDT",
+        timeframe="2m",
+        enabled=True,
+        env="testnet",
+        side_whitelist=SideWhitelist.BOTH,
+        leverage=5,
+        use_balance_pct=False,
+        balance_pct=Decimal("0"),
+        fixed_notional=Decimal("10"),
+        max_position_usdt=None,
+    )
+
+
+def _make_signal(side: OrderSide, *, trigger: Decimal, stop: Decimal) -> ArmSignal:
+    now = datetime.now(timezone.utc)
+    return ArmSignal(
+        version="1",
+        side=side,
+        symbol="BTCUSDT",
+        timeframe="2m",
+        ts_ms=int(now.timestamp() * 1000),
+        ts=now,
+        ind_ts_ms=int(now.timestamp() * 1000),
+        ind_ts=now,
+        ind_high=trigger + Decimal("1"),
+        ind_low=stop - Decimal("1"),
+        trigger=trigger,
+        stop=stop,
+    )
+
+
+def _make_state(bot_id, side: OrderSide, *, trigger: Decimal, stop: Decimal) -> OrderState:
+    return OrderState(
+        bot_id=bot_id,
+        signal_id="sig-1",
+        status=OrderStatus.PENDING,
+        side=side,
+        symbol="BTCUSDT",
+        trigger_price=trigger,
+        stop_price=stop,
+        quantity=Decimal("0.01"),
+        order_id=12345,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "entry_side, expected_exit, trigger, stop",
+    [
+        (OrderSide.LONG, OrderSide.SHORT, Decimal("100"), Decimal("98")),
+        (OrderSide.SHORT, OrderSide.LONG, Decimal("100"), Decimal("102")),
+    ],
+)
+async def test_stop_loss_uses_exit_side(entry_side, expected_exit, trigger, stop) -> None:
+    bot = _make_bot()
+    signal = _make_signal(entry_side, trigger=trigger, stop=stop)
+    state = _make_state(bot.id, entry_side, trigger=trigger, stop=stop)
+    executor = OrderExecutorStub(state)
+    positions = PositionManagerStub(take_profit=trigger)
+    trading = TradingStub(order_status="NEW")
+
+    worker = BotWorker(bot, executor, positions, trading)
+    await worker.handle_arm_signal(signal, "msg-1")
+
+    assert trading.stop_orders, "Stop-loss order should be placed"
+    stop_order = trading.stop_orders[0]
+    assert stop_order["order_type"] == "STOP_MARKET"
+    assert stop_order["side"] == expected_exit
+
+
+@pytest.mark.asyncio
+async def test_take_profit_order_created_on_fill() -> None:
+    bot = _make_bot()
+    trigger = Decimal("100")
+    stop = Decimal("98")
+    signal = _make_signal(OrderSide.LONG, trigger=trigger, stop=stop)
+    state = _make_state(bot.id, OrderSide.LONG, trigger=trigger, stop=stop)
+    executor = OrderExecutorStub(state)
+    positions = PositionManagerStub(take_profit=Decimal("105"))
+    trading = TradingStub(order_status="FILLED")
+
+    worker = BotWorker(bot, executor, positions, trading)
+    await worker.handle_arm_signal(signal, "msg-1")
+
+    # Clear any previous stop order recordings for clarity
+    trading.stop_orders.clear()
+
+    await worker._check_order_fill()
+
+    assert state.status == OrderStatus.FILLED
+    assert positions.calls, "open_position should have been invoked"
+    assert len(trading.stop_orders) == 1
+    take_profit_order = trading.stop_orders[0]
+    assert take_profit_order["order_type"] == "TAKE_PROFIT_MARKET"
+    assert take_profit_order["side"] == OrderSide.SHORT
+    assert take_profit_order["stop_price"] == Decimal("105")


### PR DESCRIPTION
## Summary
- track the active ARM in the calc signal generator and emit DISARM/ARM when a new indicator candle arrives in the same regime
- add exit-side helpers so worker stop-loss and take-profit orders close positions correctly and place a TP order after fills
- add unit tests covering signal refresh behaviour and the worker stop/take-profit flows

## Testing
- pytest tests/unit/calc2/test_signal_generator.py tests/unit/core/test_bot_worker.py

------
https://chatgpt.com/codex/tasks/task_e_690a59cf2afc8322b80e913b656fd9b7