### PR TITLE
Refactor order placement for atomic trio handling

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -29,6 +29,19 @@ mypy app
 ruff check app
 ```
 
+### Targeted worker tests
+
+The order pipeline now enforces atomic placement of entry/stop/take-profit
+orders through `OrderPlacementService`. To validate the updated behaviour run:
+
+```bash
+pytest tests/unit/worker/test_order_executor.py
+```
+
+This covers trio placement success and rollback on take-profit failures, while
+exercising the new balance re-use and failure-path handling inside
+`OrderExecutor`.
+
 ## Smoke Test
 
 With `BINANCE_TESTNET=true` and valid credentials in the environment, a quick

--- a/app/scripts/debug_sizing.py
+++ b/app/scripts/debug_sizing.py
@@ -301,8 +301,18 @@ class ScriptBalanceValidator:
     binance_account: ScriptBinanceAccount
     balance_cache: ScriptBalanceCache
 
-    async def validate_balance(self, bot: BotConfig, required_margin: Decimal) -> Tuple[bool, Decimal]:
-        available = await self.get_available_balance(bot.cred_id, bot.env)
+    async def validate_balance(
+        self,
+        bot: BotConfig,
+        required_margin: Decimal,
+        *,
+        available_balance: Decimal | None = None,
+    ) -> Tuple[bool, Decimal]:
+        available = (
+            available_balance
+            if available_balance is not None
+            else await self.get_available_balance(bot.cred_id, bot.env)
+        )
         return (available >= required_margin), available
 
     async def get_available_balance(self, cred_id, env) -> Decimal:
@@ -396,7 +406,7 @@ async def main() -> None:
     pre_qty = _calc_qty(bot, available, trigger)
     exposure = pre_qty * trigger
     required_margin = exposure / Decimal(bot.leverage if bot.leverage > 0 else 1)
-    ok, _ = await validator.validate_balance(bot, required_margin)
+    ok, _ = await validator.validate_balance(bot, required_margin, available_balance=available)
 
     print(f"Pre-quant qty       : {pre_qty}")
     print(f"Exposure (qty*px)   : {exposure}")

--- a/app/scripts/fake_signal.py
+++ b/app/scripts/fake_signal.py
@@ -244,6 +244,7 @@ async def run_dry_run(
         order_executor=order_executor,
         order_gateway=order_gateway,
         trading_factory=trading_factory,
+        position_store=position_manager,
     )
 
     # Build full ArmSignal (your model requires these fields)

--- a/app/services/order_placement.py
+++ b/app/services/order_placement.py
@@ -1,0 +1,205 @@
+"""Order placement orchestration helpers used by the worker OrderExecutor."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Mapping, Optional, Protocol, Sequence
+
+from app.services.worker.domain.enums import OrderSide, exit_side_for
+from app.services.worker.domain.exceptions import (
+    BinanceAPIException,
+    BinanceBadRequestException,
+    BinanceExchangeDownException,
+    BinanceRateLimitException,
+    DomainBadRequest,
+    DomainExchangeDown,
+    DomainExchangeError,
+    DomainRateLimit,
+)
+
+
+class TradingPort(Protocol):
+    async def create_limit_order(
+        self,
+        *,
+        symbol: str,
+        side: OrderSide,
+        quantity: Decimal,
+        price: Decimal,
+        reduce_only: bool,
+        time_in_force: str,
+        new_client_order_id: Optional[str] = None,
+    ) -> dict: ...
+
+    async def create_stop_market_order(
+        self,
+        *,
+        symbol: str,
+        side: OrderSide,
+        quantity: Decimal,
+        stop_price: Decimal,
+        reduce_only: bool,
+        order_type: str,
+    ) -> dict: ...
+
+    async def create_take_profit_limit(
+        self,
+        *,
+        symbol: str,
+        side: OrderSide,
+        quantity: Decimal,
+        price: Decimal,
+        stop_price: Decimal,
+        reduce_only: bool,
+        time_in_force: str,
+        new_client_order_id: Optional[str] = None,
+    ) -> dict: ...
+
+    async def cancel_order(self, *, symbol: str, order_id: int) -> None: ...
+
+
+@dataclass(slots=True)
+class TrioOrderResult:
+    entry_order_id: Optional[int]
+    stop_order_id: Optional[int]
+    take_profit_order_id: Optional[int]
+
+
+def _log_context(base: Mapping[str, str] | None) -> Mapping[str, str]:
+    return dict(base or {})
+
+
+def _to_int_or_none(value: object) -> Optional[int]:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+class OrderPlacementService:
+    """Provide atomic placement and rollback for entry/stop/take-profit orders."""
+
+    def __init__(self, trading: TradingPort, *, logger: logging.Logger | None = None) -> None:
+        self._trading = trading
+        self._log = logger or logging.getLogger(__name__)
+
+    async def place_trio_orders(
+        self,
+        *,
+        symbol: str,
+        side: OrderSide,
+        quantity: Decimal,
+        entry_price: Decimal,
+        stop_price: Decimal,
+        take_profit_price: Decimal,
+        reduce_only: bool = False,
+        context: Mapping[str, str] | None = None,
+    ) -> TrioOrderResult:
+        ctx = _log_context(context)
+        exit_side = exit_side_for(side)
+
+        try:
+            entry_resp = await self._trading.create_limit_order(
+                symbol=symbol,
+                side=side,
+                quantity=quantity,
+                price=entry_price,
+                reduce_only=reduce_only,
+                time_in_force="GTC",
+            )
+        except DomainBadRequest as exc:
+            raise BinanceBadRequestException(str(exc)) from exc
+        except DomainRateLimit as exc:
+            raise BinanceRateLimitException(str(exc)) from exc
+        except DomainExchangeDown as exc:
+            raise BinanceExchangeDownException(str(exc)) from exc
+        except DomainExchangeError as exc:
+            raise BinanceAPIException(str(exc)) from exc
+        except Exception as exc:  # noqa: BLE001
+            raise BinanceAPIException(f"Unexpected create_limit_order error: {exc}") from exc
+
+        entry_id = _to_int_or_none(entry_resp.get("orderId")) if isinstance(entry_resp, dict) else None
+        self._log.info(
+            "order.entry_placed",
+            extra={**ctx, "symbol": symbol, "entry_order_id": entry_id, "side": side.value},
+        )
+
+        stop_id: Optional[int] = None
+        tp_id: Optional[int] = None
+
+        try:
+            stop_resp = await self._trading.create_stop_market_order(
+                symbol=symbol,
+                side=exit_side,
+                quantity=quantity,
+                stop_price=stop_price,
+                reduce_only=True,
+                order_type="STOP_MARKET",
+            )
+            stop_id = _to_int_or_none(stop_resp.get("orderId")) if isinstance(stop_resp, dict) else None
+            self._log.info(
+                "order.stop_placed",
+                extra={**ctx, "symbol": symbol, "stop_order_id": stop_id, "side": exit_side.value},
+            )
+        except Exception as exc:  # noqa: BLE001
+            await self.rollback_orders(symbol, [entry_id], context=ctx)
+            raise BinanceAPIException(f"create_stop_market_order failed: {exc}") from exc
+
+        try:
+            tp_resp = await self._trading.create_take_profit_limit(
+                symbol=symbol,
+                side=exit_side,
+                quantity=quantity,
+                price=take_profit_price,
+                stop_price=take_profit_price,
+                reduce_only=True,
+                time_in_force="GTC",
+            )
+            tp_id = _to_int_or_none(tp_resp.get("orderId")) if isinstance(tp_resp, dict) else None
+            self._log.info(
+                "order.tp_placed",
+                extra={**ctx, "symbol": symbol, "tp_order_id": tp_id, "side": exit_side.value},
+            )
+        except DomainBadRequest as exc:
+            await self.rollback_orders(symbol, [stop_id, entry_id], context=ctx)
+            raise BinanceBadRequestException(str(exc)) from exc
+        except DomainRateLimit as exc:
+            await self.rollback_orders(symbol, [stop_id, entry_id], context=ctx)
+            raise BinanceRateLimitException(str(exc)) from exc
+        except DomainExchangeDown as exc:
+            await self.rollback_orders(symbol, [stop_id, entry_id], context=ctx)
+            raise BinanceExchangeDownException(str(exc)) from exc
+        except DomainExchangeError as exc:
+            await self.rollback_orders(symbol, [stop_id, entry_id], context=ctx)
+            raise BinanceAPIException(str(exc)) from exc
+        except Exception as exc:  # noqa: BLE001
+            await self.rollback_orders(symbol, [stop_id, entry_id], context=ctx)
+            raise BinanceAPIException(f"create_take_profit_limit failed: {exc}") from exc
+
+        return TrioOrderResult(
+            entry_order_id=entry_id,
+            stop_order_id=stop_id,
+            take_profit_order_id=tp_id,
+        )
+
+    async def rollback_orders(
+        self,
+        symbol: str,
+        order_ids: Sequence[int | str | None],
+        *,
+        context: Mapping[str, str] | None = None,
+    ) -> None:
+        ctx = _log_context(context)
+        for oid in order_ids:
+            if oid in (None, ""):
+                continue
+            try:
+                await self._trading.cancel_order(symbol=symbol, order_id=int(oid))
+                self._log.info("order.rollback_cancelled", extra={**ctx, "symbol": symbol, "order_id": oid})
+            except Exception as exc:  # noqa: BLE001
+                self._log.warning(
+                    "order.rollback_failed",
+                    extra={**ctx, "symbol": symbol, "order_id": oid, "error": str(exc)},
+                )

--- a/app/services/worker/application/balance_validator.py
+++ b/app/services/worker/application/balance_validator.py
@@ -47,8 +47,20 @@ class BalanceValidator:
         self,
         bot: BotConfig,
         required_margin: Decimal,
+        *,
+        available_balance: Decimal | None = None,
     ) -> Tuple[bool, Decimal]:
-        available = await self.get_available_balance(bot.cred_id, bot.env)
+        """Validate that available balance covers ``required_margin``.
+
+        ``available_balance`` allows callers to reuse a recently fetched value
+        to avoid duplicate cache/network lookups (the validator will still
+        consult its cache if ``None`` is provided).
+        """
+        available = (
+            available_balance
+            if available_balance is not None
+            else await self.get_available_balance(bot.cred_id, bot.env)
+        )
         ok = available >= required_margin
         return ok, available
 

--- a/app/services/worker/core/logging_utils.py
+++ b/app/services/worker/core/logging_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, MutableMapping
 
-_CONTEXT_FIELDS = ("symbol", "tf", "type", "msg_id", "prev_side")
+_CONTEXT_FIELDS = ("symbol", "tf", "type", "msg_id", "prev_side", "bot_id")
 
 
 def format_log_context(context: Mapping[str, Any]) -> str:

--- a/app/services/worker/domain/exceptions.py
+++ b/app/services/worker/domain/exceptions.py
@@ -25,14 +25,30 @@ class BinanceAPIException(WorkerException):
     """Raised when Binance API returns an error that should surface to the application."""
 
 
+class BinanceBadRequestException(BinanceAPIException):
+    """Raised when Binance rejects a request due to invalid parameters."""
+
+
+class BinanceRateLimitException(BinanceAPIException):
+    """Raised when Binance signals a rate-limit condition."""
+
+
+class BinanceExchangeDownException(BinanceAPIException):
+    """Raised when Binance is unavailable due to server/network failure."""
+
+
 class OrderNotFoundException(WorkerException):
     """Raised when an order expected to exist cannot be found."""
+
 
 __all__ = [
     "WorkerException",
     "InsufficientBalanceException",
     "InvalidSignalException",
     "BinanceAPIException",
+    "BinanceBadRequestException",
+    "BinanceRateLimitException",
+    "BinanceExchangeDownException",
     "OrderNotFoundException",
     "DomainBadRequest",
     "DomainAuthError",

--- a/app/services/worker/main.py
+++ b/app/services/worker/main.py
@@ -170,6 +170,7 @@ async def main_async() -> None:
         order_executor=order_executor,
         order_gateway=order_gateway,
         trading_factory=trading_factory,
+        position_store=position_manager,
     )
     log.info("Application services initialized")
 


### PR DESCRIPTION
## Summary
- introduce an OrderPlacementService that atomically places entry/stop/take-profit orders and centralises rollback logic
- refactor OrderExecutor to reuse balance lookups, enrich logging context, and return consistent OrderState results while wiring in the new service
- update SignalProcessor to include bot identifiers in logs, consult active positions, and document the new workflow in README-dev
- expand unit coverage around order placement success and rollback scenarios

## Testing
- pytest tests/unit/worker/test_order_executor.py

------
https://chatgpt.com/codex/tasks/task_e_690bc21fdb788322bd2193e2a3add069