### PR TITLE
Improve signal guardrails and pyramiding support

### DIFF
--- a/tests/unit/worker/test_position_manager.py
+++ b/tests/unit/worker/test_position_manager.py
@@ -1,0 +1,74 @@
+import pytest
+
+from dataclasses import replace
+from decimal import Decimal
+from uuid import uuid4
+
+from app.services.worker.application.position_manager import PositionManager
+from app.services.worker.domain.enums import OrderSide, OrderStatus
+from app.services.worker.domain.models import OrderState
+
+
+class BinanceClientStub:
+    def __init__(self) -> None:
+        self.closed_calls: list[tuple[str, str, Decimal]] = []
+
+    async def close_position_market(self, symbol: str, side: str, quantity: Decimal) -> dict:
+        self.closed_calls.append((symbol, side, quantity))
+        return {}
+
+    async def get_mark_price(self, symbol: str) -> Decimal:
+        raise NotImplementedError
+
+    async def get_open_position_qty(self, symbol: str) -> Decimal:
+        raise NotImplementedError
+
+
+def _filled_state(quantity: Decimal) -> OrderState:
+    return OrderState(
+        bot_id=uuid4(),
+        signal_id="msg",
+        status=OrderStatus.FILLED,
+        side=OrderSide.LONG,
+        symbol="BTCUSDT",
+        trigger_price=Decimal("100"),
+        stop_price=Decimal("95"),
+        quantity=quantity,
+    )
+
+
+@pytest.mark.asyncio
+async def test_open_position_tracks_multiple_entries() -> None:
+    client = BinanceClientStub()
+    manager = PositionManager(client)
+
+    bot_id = uuid4()
+    state_one = replace(_filled_state(Decimal("0.1")), bot_id=bot_id)
+    state_two = replace(_filled_state(Decimal("0.2")), bot_id=bot_id)
+
+    await manager.open_position(bot_id, state_one)
+    await manager.open_position(bot_id, state_two)
+
+    positions = manager.get_positions(bot_id)
+
+    assert len(positions) == 2
+    assert manager.get_position(bot_id) == positions[-1]
+    assert positions[-1].quantity == Decimal("0.2")
+
+
+@pytest.mark.asyncio
+async def test_close_position_sums_quantities() -> None:
+    client = BinanceClientStub()
+    manager = PositionManager(client)
+
+    bot_id = uuid4()
+    state_one = replace(_filled_state(Decimal("0.1")), bot_id=bot_id)
+    state_two = replace(_filled_state(Decimal("0.3")), bot_id=bot_id)
+
+    await manager.open_position(bot_id, state_one)
+    await manager.open_position(bot_id, state_two)
+
+    await manager.close_position(bot_id, "exit")
+
+    assert manager.get_positions(bot_id) == []
+    assert client.closed_calls == [("BTCUSDT", "SELL", Decimal("0.4"))]

--- a/tests/unit/worker/test_signal_processor.py
+++ b/tests/unit/worker/test_signal_processor.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dataclasses import replace
 from decimal import Decimal
 from datetime import datetime, timezone
 from typing import Iterable, List
@@ -7,7 +8,7 @@ from uuid import UUID, uuid4
 
 from app.services.worker.application.signal_processor import SignalProcessor
 from app.services.worker.domain.enums import OrderSide, OrderStatus, SideWhitelist
-from app.services.worker.domain.models import ArmSignal, BotConfig, DisarmSignal, OrderState
+from app.services.worker.domain.models import ArmSignal, BotConfig, DisarmSignal, OrderState, Position
 
 
 class RouterStub:
@@ -29,12 +30,20 @@ class BotRepositoryStub:
 
 
 class OrderGatewayStub:
-    def __init__(self, states: List[OrderState]) -> None:
-        self._states = states
+    def __init__(self, states: List[OrderState] | None = None) -> None:
+        self._states = list(states or [])
         self.saved: List[OrderState] = []
 
     async def list_pending_order_states(self, bot_id, symbol, side, statuses=None):
-        return list(self._states)
+        records = []
+        status_filter = set(statuses) if statuses else None
+        for state in self._states + self.saved:
+            if state.bot_id != bot_id or state.symbol != symbol or state.side != side:
+                continue
+            if status_filter and state.status not in status_filter:
+                continue
+            records.append(state)
+        return list(records)
 
     async def save_state(self, state: OrderState) -> None:
         self.saved.append(state)
@@ -55,6 +64,27 @@ class OrderExecutorStub:
     async def execute_order(self, bot: BotConfig, signal: ArmSignal) -> OrderState:
         self.executed = True
         raise AssertionError("execute_order should not be called when active trades exist")
+
+
+class SuccessfulExecutorStub:
+    def __init__(self) -> None:
+        self.calls: List[tuple[UUID, OrderSide]] = []
+        self.counter = 0
+
+    async def execute_order(self, bot: BotConfig, signal: ArmSignal) -> OrderState:
+        self.calls.append((bot.id, signal.side))
+        self.counter += 1
+        quantity = Decimal("0.1") * self.counter
+        return OrderState(
+            bot_id=bot.id,
+            signal_id=signal.signal_msg_id or "",
+            status=OrderStatus.PENDING,
+            side=signal.side,
+            symbol=signal.symbol,
+            trigger_price=signal.trigger,
+            stop_price=signal.stop,
+            quantity=quantity,
+        )
 
 
 def _make_bot() -> BotConfig:
@@ -175,3 +205,157 @@ async def test_arm_signal_skips_when_active_trade_present() -> None:
     assert results == []
     assert not executor.executed
     assert not orders.saved
+
+
+@pytest.mark.asyncio
+async def test_arm_signal_records_skipped_whitelist_state() -> None:
+    bot = replace(_make_bot(), side_whitelist=SideWhitelist.LONG)
+
+    router = RouterStub([bot.id])
+    bots = BotRepositoryStub(bot)
+    orders = OrderGatewayStub()
+    executor = SuccessfulExecutorStub()
+
+    async def trading_factory(_: BotConfig):
+        return TradingStub()
+
+    processor = SignalProcessor(router, bots, executor, orders, trading_factory)
+
+    arm_signal = _arm_signal(OrderSide.SHORT)
+    results = await processor.process_arm_signal(arm_signal, "msg-1")
+
+    assert results
+    state = orders.saved[0]
+    assert state.status == OrderStatus.SKIPPED_WHITELIST
+    assert state.symbol == arm_signal.symbol
+    assert state.side == OrderSide.SHORT
+    assert state.bot_id == bot.id
+    assert executor.calls == []
+
+
+@pytest.mark.asyncio
+async def test_disabled_bot_logs_and_skips(caplog: pytest.LogCaptureFixture) -> None:
+    bot = replace(_make_bot(), enabled=False)
+
+    router = RouterStub([bot.id])
+    bots = BotRepositoryStub(bot)
+    orders = OrderGatewayStub()
+
+    async def trading_factory(_: BotConfig):
+        return TradingStub()
+
+    processor = SignalProcessor(router, bots, SuccessfulExecutorStub(), orders, trading_factory)
+
+    with caplog.at_level("INFO"):
+        results = await processor.process_arm_signal(_arm_signal(OrderSide.LONG), "msg-2")
+
+    assert not results
+    assert not orders.saved
+    assert any(f"Skipping disabled bot {bot.id}" in message for message in caplog.messages)
+
+
+@pytest.mark.asyncio
+async def test_second_signal_skipped_when_pyramiding_disabled() -> None:
+    bot = _make_bot()
+
+    router = RouterStub([bot.id])
+    bots = BotRepositoryStub(bot)
+
+    initial_state = OrderState(
+        bot_id=bot.id,
+        signal_id="msg-0",
+        status=OrderStatus.PENDING,
+        side=OrderSide.LONG,
+        symbol=bot.symbol,
+        trigger_price=Decimal("100"),
+        stop_price=Decimal("95"),
+        quantity=Decimal("1"),
+    )
+
+    orders = OrderGatewayStub([initial_state])
+    executor = OrderExecutorStub()
+
+    async def trading_factory(_: BotConfig):
+        return TradingStub()
+
+    processor = SignalProcessor(router, bots, executor, orders, trading_factory)
+
+    results = await processor.process_arm_signal(_arm_signal(OrderSide.LONG), "msg-3")
+
+    assert not results
+    assert not orders.saved
+    assert not executor.executed
+
+
+class PositionStoreStub:
+    def __init__(self) -> None:
+        self.positions: List[Position] = []
+
+    def get_position(self, bot_id: UUID):
+        matches = self.get_positions(bot_id)
+        return matches[-1] if matches else None
+
+    def get_positions(self, bot_id: UUID):
+        return [p for p in self.positions if p.bot_id == bot_id]
+
+
+@pytest.mark.asyncio
+async def test_dual_signal_processed_when_pyramiding_enabled() -> None:
+    bot = _make_bot()
+    object.__setattr__(bot, "allow_pyramiding", True)
+
+    router = RouterStub([bot.id])
+    bots = BotRepositoryStub(bot)
+    orders = OrderGatewayStub()
+    executor = SuccessfulExecutorStub()
+    position_store = PositionStoreStub()
+
+    async def trading_factory(_: BotConfig):
+        return TradingStub()
+
+    processor = SignalProcessor(
+        router,
+        bots,
+        executor,
+        orders,
+        trading_factory,
+        position_store=position_store,
+    )
+
+    signal = _arm_signal(OrderSide.LONG)
+    results_first = await processor.process_arm_signal(signal, "msg-4")
+    # simulate fill storing positions
+    first_state = results_first[0]
+    position_store.positions.append(
+        Position(
+            bot_id=bot.id,
+            symbol=first_state.symbol,
+            side=first_state.side,
+            entry_price=first_state.trigger_price,
+            quantity=first_state.quantity,
+            stop_loss=first_state.stop_price,
+            take_profit=first_state.trigger_price + Decimal("10"),
+        )
+    )
+
+    results_second = await processor.process_arm_signal(signal, "msg-5")
+
+    second_state = results_second[0]
+    position_store.positions.append(
+        Position(
+            bot_id=bot.id,
+            symbol=second_state.symbol,
+            side=second_state.side,
+            entry_price=second_state.trigger_price,
+            quantity=second_state.quantity,
+            stop_loss=second_state.stop_price,
+            take_profit=second_state.trigger_price + Decimal("12"),
+        )
+    )
+
+    assert len(results_first) == 1
+    assert len(results_second) == 1
+    assert len(orders.saved) == 2
+    assert orders.saved[0].signal_id == "msg-4"
+    assert orders.saved[1].signal_id == "msg-5"
+    assert len(position_store.get_positions(bot.id)) == 2


### PR DESCRIPTION
## Summary
- ensure the signal processor persists whitelist skips, logs disabled bots, and respects pyramiding guardrails
- extend the position manager to track multiple active entries per bot
- add unit coverage for whitelist skips, pyramiding behaviour, and position aggregation

## Testing
- pytest tests/unit/worker

------
https://chatgpt.com/codex/tasks/task_e_690bf31f924883228f1f0b1fd76f391c